### PR TITLE
feat: add OpenID client ID and secret parameters to Bicep templates

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,4 +41,6 @@ jobs:
               --parameters postgresServerAdminLogin="${{ secrets.POSTGRES_ADMIN_LOGIN }}" \
                            postgresServerAdminPassword="${{ secrets.POSTGRES_ADMIN_PASSWORD }}" \
                            adminObjectId="${{ secrets.ADMIN_OBJECT_ID }}" \
-                           litellmMasterKey="${{ secrets.LITELLM_MASTER_KEY }}"
+                           litellmMasterKey="${{ secrets.LITELLM_MASTER_KEY }}" \
+                           openidClientId="${{ secrets.OPEN_ID_CLIENT_ID }}" \
+                           openidClientSecret="${{ secrets.OPEN_ID_CLIENT_SECRET }}"

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -28,6 +28,13 @@ param litellmName string
 param openWebUIImage string
 param litellmImage string
 
+@secure()
+param openidClientId string
+
+@secure()
+param openidClientSecret string
+
+
 // =====================
 // MODULES
 // =====================
@@ -92,6 +99,8 @@ module keyVaultModule './modules/keyVault.bicep' = {
     postgresUsernameSecretValue: postgresServerAdminLogin
     postgresURLSecretValue: 'postgresql://${postgresServerAdminLogin}:${postgresServerAdminPassword}@${postgresServerName}.postgres.database.azure.com:5432/postgres?sslmode=require'
     litellmMasterKeySecretValue: litellmMasterKey
+    openidClientIdSecretValue: openidClientId
+    openidClientSecretValue: openidClientSecret
   }
 }
 

--- a/infra/bicep/modules/keyVault.bicep
+++ b/infra/bicep/modules/keyVault.bicep
@@ -13,7 +13,10 @@ param postgresUsernameSecretValue string // Benutzername für PostgreSQL-Datenba
 param postgresURLSecretValue string // Verbindungs-URL für PostgreSQL-Datenbank, die als Secret im Vault gespeichert wird
 @secure()
 param litellmMasterKeySecretValue string
-
+@secure() 
+param openidClientIdSecretValue string
+@secure()
+param openidClientSecretValue string
 
 resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: keyVaultName
@@ -92,5 +95,20 @@ resource postgresURLSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   }
 }
 
+resource openidClientIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: vault
+  name: 'OpenIDClientId'
+  properties: {
+    value: openidClientIdSecretValue
+  }
+}
+
+resource openidClientSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: vault
+  name: 'OpenIDClientSecret'
+  properties: {
+    value: openidClientSecretValue
+  }
+}
 
 output vaultUri string = vault.properties.vaultUri


### PR DESCRIPTION
This pull request adds support for securely managing OpenID client credentials in the infrastructure deployment process. The changes introduce new parameters for the OpenID client ID and secret, ensure these values are handled securely, and store them as secrets in Azure Key Vault during deployment.

**Infrastructure and Secrets Management:**

* Added secure parameters `openidClientId` and `openidClientSecret` to the main Bicep deployment template (`main.bicep`) to accept OpenID credentials as deployment inputs.
* Updated the Key Vault module (`modules/keyVault.bicep`) to accept and securely store the OpenID client ID and secret as secrets in Azure Key Vault. [[1]](diffhunk://#diff-895aa2bbc44e46cce999722105f56095331b108396555d9e9951b91187f88f15L16-R19) [[2]](diffhunk://#diff-895aa2bbc44e46cce999722105f56095331b108396555d9e9951b91187f88f15R98-R112)
* Modified the main Bicep template to pass the new OpenID parameters to the Key Vault module, ensuring they are provisioned as secrets.

**Deployment Workflow:**

* Updated the GitHub Actions deployment workflow (`.github/workflows/deploy.yaml`) to pass the OpenID client ID and secret from repository secrets to the deployment parameters.